### PR TITLE
Enforce bash as environment

### DIFF
--- a/nixpkgs.sh
+++ b/nixpkgs.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# In case the system uses a non-POSIX shell, like fish or nushell,
+# we want to ensure run also our forked processes in a bash environment.
+SHELL="bash"
+
 # === Change keybinds or add more here ===
 
 declare -a INDEXES=(


### PR DESCRIPTION
Fixes #5 by setting `bash` explicitly as `$SHELL` to enforce processes that fork from `nixpkgs.sh` are executed in a bash environment.
