### PR TITLE
nixpkgs-sh nix modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,119 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1742394900,
+        "narHash": "sha256-vVOAp9ahvnU+fQoKd4SEXB2JG2wbENkpqcwlkIXgUC0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "70947c1908108c0c551ddfd73d4f750ff2ea67cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_2": {
+      "inputs": {
+        "nixpkgs": [
+          "noogle-cli",
+          "noogle",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700327093,
+        "narHash": "sha256-OgYvlBABxJYWhZ/HBd0bPVcIEkT+xDhDCpRYqtVhYWY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "ae7cd510e508ee03d792005c2f1c0a3ff25ecb80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "noogle-cli",
+          "noogle",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "noogle-cli",
+          "noogle",
+          "nix-master",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -15,6 +129,127 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": [
+          "noogle-cli",
+          "noogle",
+          "nix-master"
+        ],
+        "gitignore": [
+          "noogle-cli",
+          "noogle",
+          "nix-master"
+        ],
+        "nixpkgs": [
+          "noogle-cli",
+          "noogle",
+          "nix-master",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "noogle-cli",
+          "noogle",
+          "nix-master",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1734279981,
+        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "noogle-cli",
+          "noogle",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nix-master": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts_2",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-23-11": "nixpkgs-23-11",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1741823126,
+        "narHash": "sha256-vcTBc42TcyBus43Hzx0Gkfa8q6txPrAU6Eh++5yHMN8=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "b8eaf1b3228aab1b795a8fe42b92cbb2866361d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nix",
         "type": "github"
       }
     },
@@ -34,10 +269,209 @@
         "type": "github"
       }
     },
+    "nixpkgs-23-11": {
+      "locked": {
+        "lastModified": 1717159533,
+        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      }
+    },
+    "nixpkgs-master": {
+      "locked": {
+        "lastModified": 1742671702,
+        "narHash": "sha256-W2QyO8zsqZQjmNrpBVYkKwebaqPuBgpF8DxaEGe8K0k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cec6992f27a0cb6e0f52c2e973be2cab171a099c",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "master",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1734359947,
+        "narHash": "sha256-1Noao/H+N8nFB4Beoy8fgwrcOQLVm9o4zKW1ODaqK9E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "48d12d5e70ee91fe8481378e540433a7303dbf6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1739446958,
+        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "noogle": {
+      "inputs": {
+        "crane": "crane_2",
+        "flake-parts": "flake-parts",
+        "nix-master": "nix-master",
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-master": [
+          "noogle-cli",
+          "nixpkgs-master"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks",
+        "systems": [
+          "noogle-cli",
+          "systems"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1747622892,
+        "narHash": "sha256-k9cbwmJOzMK693w5CImaOtBS97YMHA4SvUldXSsiB4M=",
+        "owner": "nix-community",
+        "repo": "noogle",
+        "rev": "be0b702d2152c765645e9ce2c8cf4e9792641915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "noogle",
+        "type": "github"
+      }
+    },
+    "noogle-cli": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-master": "nixpkgs-master",
+        "noogle": "noogle",
+        "rust-overlay": "rust-overlay",
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1747636136,
+        "narHash": "sha256-pYOfnNUMfJBFF7Ri07BNZfxoYtgWuqWUTEROdqeaGUA=",
+        "owner": "juliamertz",
+        "repo": "noogle-cli",
+        "rev": "14b9e7d15bf46f9168690fdb17dd34193034e427",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juliamertz",
+        "repo": "noogle-cli",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_3",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "noogle-cli",
+          "noogle",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1700064067,
+        "narHash": "sha256-1ZWNDzhu8UlVCK7+DUN9dVQfiHX1bv6OQP9VxstY/gs=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "e558068cba67b23b4fbc5537173dbb43748a17e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "noogle-cli": "noogle-cli"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "noogle-cli",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742610648,
+        "narHash": "sha256-9jWi3gw3fEIgEslnFjH/s1I+Iyf1+4t5B1Ed1FOiy8o=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c60d41987df3c853e2a842de2c63ded40400979b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {
@@ -52,6 +486,73 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "noogle-cli",
+          "noogle",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1699786194,
+        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "e82f32aa7f06bbbd56d7b12186d555223dc399d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     flake-utils,
     ...
   }:
-    flake-utils.lib.eachDefaultSystem (
+    (flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
 
@@ -72,5 +72,12 @@
           };
         };
       }
-    );
+    )) // {
+      nixosModules = {
+        nixpkgs-sh = (import ./nixpkgs-sh.nix "nixos");
+      };
+      homeManagerModules = {
+        nixpkgs-sh = (import ./nixpkgs-sh.nix "home-manager");
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,17 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    noogle-cli = {
+      url = "github:juliamertz/noogle-cli";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
     flake-utils,
+    noogle-cli,
     ...
   }:
     (flake-utils.lib.eachDefaultSystem (
@@ -74,10 +79,10 @@
       }
     )) // {
       nixosModules = {
-        nixpkgs-sh = (import ./nixpkgs-sh.nix "nixos");
+        nixpkgs-sh = (import ./nixpkgs-sh.nix "nixos" noogle-cli);
       };
       homeManagerModules = {
-        nixpkgs-sh = (import ./nixpkgs-sh.nix "home-manager");
+        nixpkgs-sh = (import ./nixpkgs-sh.nix "home-manager" noogle-cli);
       };
     };
 }

--- a/nixpkgs-sh.nix
+++ b/nixpkgs-sh.nix
@@ -1,0 +1,117 @@
+type:
+{lib, config, pkgs, ...}:
+let
+  inherit (lib) mkOption mkEnableOption types last head splitString concatLines mapAttrsToList mkIf replaceStrings;
+  options =  {
+    programs.nix-search-tv-script = {
+      enable = mkEnableOption "Wether to include the nix-serach-tv-script";
+      outputPackage = mkOption {
+        description = "when enabled this option provides the outputPackage with the settings";
+        type = types.package;
+      };
+      outputPackageName = mkOption {
+        type = types.str;
+        description = "name of the package, use this to run the command";
+        default = "nixpkgs-sh";
+      };
+      settings = {
+        indexes = {
+          real = mkOption {
+             default = {
+               "nixpkgs" = "ctrl-n";
+               "home-manager" = "ctrl-h";
+             };
+             type = with types; attrsOf str;
+        };
+         pseudo = mkOption {
+           default = {
+             "all" = "ctrl-a";
+           };
+           type = with types; attrsOf str;
+         };
+        };
+        keys = {
+          searchSnippet = mkOption {
+            default = "ctrl-w";
+            type = types.str;
+          };
+          openSource = mkOption {
+            default = "ctrl-s";
+            type = types.str;
+          };
+          openHomepage = mkOption {
+             default = "ctrl-o";
+             type = types.str;
+          };
+          nixShell = mkOption {
+            default = "ctrl-i";
+            type = types.str;
+          };
+          printPreview = mkOption {
+            default = "alt-p";
+            type = types.str;
+          };
+
+        };
+        opener = mkOption {
+           default = "xdg-open";
+           type = with types; either package str;
+        };
+        stateFile = mkOption {
+          default = "/tmp/nix-search-tv-fzf";
+          type = types.path;
+          
+        };
+      };
+
+    };
+  };
+  cfg = config.programs.nix-search-tv-script; 
+  script_text = builtins.readFile ./nixpkgs.sh;
+  script_without_config_tail= (last (splitString "# ========================================" script_text));
+  script_without_config_head = (head (splitString "# === Change keybinds or add more here ===" script_text));
+  map_indexes_to_config = idxs:  concatLines (mapAttrsToList (name: value: "\"${name} ${value}\"") idxs);
+  out_pkg_list = [ cfg.outputPackage ];
+
+in
+{
+  inherit options;
+  config = mkIf cfg.enable  ({
+    programs.nix-search-tv-script.outputPackage = pkgs.writeShellApplication {
+      
+      name = cfg.outputPackageName;
+      excludeShellChecks = [ "SC2016" ];
+      runtimeInputs = [ pkgs.fzf];
+      text =
+      script_without_config_head +
+    ''
+      declare -a INDEXES=(
+          ${ map_indexes_to_config cfg.settings.indexes.real }
+
+          # you can add any indexes combination here,
+          # like `nixpkgs,nixos`
+          ${ map_indexes_to_config cfg.settings.indexes.pseudo }
+
+      )
+
+      SEARCH_SNIPPET_KEY=${cfg.settings.keys.searchSnippet}
+      OPEN_SOURCE_KEY=${cfg.settings.keys.openSource}
+      OPEN_HOMEPAGE_KEY=${cfg.settings.keys.openHomepage}
+      NIX_SHELL_KEY=${cfg.settings.keys.nixShell}
+      PRINT_PREVIEW_KEY=${cfg.settings.keys.printPreview}
+
+      OPENER="${cfg.settings.opener}"
+    '' + (
+      replaceStrings [
+        "/tmp/nix-search-tv-fzf"
+      ] [
+        cfg.settings.stateFile
+      ] script_without_config_tail);
+    
+    };
+  } // (if type == "home-manager" then {
+      home.packages = out_pkg_list;
+    } else if types == "nixos" then {
+      environment.systemPackages = out_pkg_list;
+  } else (abort "select either home-manager or nixos as target")));
+}


### PR DESCRIPTION
Hi, quickly packaged the shellscript with options as a nix package.
Not sure if this is in scope of this repo. especially for nix users this should provide a better way of getting started.
currently relies on a rebase version of noogle-cli as the patch / diff from the original does not apply currently. 
If you want to i can open a pr for this as well

Maybe at some point this could be refactored into writing the shell script in a string in nix and then generating the plain .sh as an artifact uploaded via github acctions



Sorry for my bad english. I am not a native speaker
