### PR TITLE
fix: not escaped quotes causes build errors

### DIFF
--- a/nixpkgs.sh
+++ b/nixpkgs.sh
@@ -103,7 +103,7 @@ SEARCH_SNIPPET_CMD="$SEARCH_SNIPPET_CMD | tr -d \"\'\" "
 SEARCH_SNIPPET_CMD="$SEARCH_SNIPPET_CMD | awk \'{ if (\$2) { print \$2 } else print \$1 }\' "
 SEARCH_SNIPPET_CMD="$SEARCH_SNIPPET_CMD | xargs printf \"https://github.com/search?type=code&q=lang:nix+%s\" \$1 "
 
-NIX_SHELL_CMD='nix-shell --run $SHELL -p $(echo "{}" | sed "s:nixpkgs/::g"'
+NIX_SHELL_CMD="nix-shell --run \$SHELL -p \$(echo \"{}\" | sed \"s:nixpkgs/::g\""
 NIX_SHELL_CMD="$NIX_SHELL_CMD | tr -d \"\'\")"
 
 PREVIEW_WINDOW="wrap"


### PR DESCRIPTION
If .sh used as a raw path argument to readFile -> causes an error in the build process

nixos 25.11 
8664 linux
nothing fancy in system

Error ( full trace ) + Context ( flake.nix home.nix )
https://gist.github.com/GodBuddy/6b2d6ecba5b7eefc2e9a4490e872e014

The fix should not cause any change in logic, should not break anything.

As a newbie to nix it took almost 4 hours to dissect the problem; 
yes i know that this strange way to use the package, but i wanted it nevertheless
