### PR TITLE
fix: use same binary path for build and run scripts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
         mkScript = name: text: pkgs.writeShellScriptBin name text;
         scripts = [
-          (mkScript "build" "GOEXPERIMENT=jsonv2 go build -o $DEV_DIR/bin $CMD_DIR")
+          (mkScript "build" "GOEXPERIMENT=jsonv2 go build -o $DEV_DIR/bin/nix-search-tv $CMD_DIR")
           (mkScript "run" "$DEV_DIR/bin/nix-search-tv $@ --config $DEV_DIR/config.json")
           (mkScript "print-search" "run print")
           (mkScript "preview-search" "run preview $@")


### PR DESCRIPTION
On a new environment the previous `build` command was creating the binary as `.dev/bin` file, but `run` expects a binary at `.dev/bin/nix-search-tv` so it was failing.