### PR TITLE
feat: add install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# nix-search-tv
+# nix-search-tv-install
 
-Fuzzy search for NixOS packages.
+Fuzzy search for NixOS packages and install them easily with automatic insertion in `configuration.nix` and system rebuild.
+
+The `configuration.nix` file has to respect the [nixfmt](https://github.com/NixOS/nixfmt) formatting.
+
+Fork of [nix-search-tv](https://github.com/3timeslazy/nix-search-tv) with an `install` command. 
 
 ---
 
@@ -20,7 +24,16 @@ Fuzzy search for NixOS packages.
 ### Nix Package
 
 ```nix
-environment.systemPackages = [ nix-search-tv ]
+environment.systemPackages = [ 
+    (nix-search-tv.overrideAttrs (oldAttrs: {
+      src = fetchFromGitHub {
+        owner = "gschurck";
+        repo = "nix-search-tv-install";
+        rev = "feat/add-install-command";
+        hash = "<latest_sha256_hash>";
+      };
+    }))
+]
 ```
 
 ### Flake
@@ -31,7 +44,7 @@ There are many ways how one can install a package from a flake, below is one:
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nix-search-tv.url = "github:3timeslazy/nix-search-tv";
+    nix-search-tv.url = "github:gschurck/nix-search-tv-install";
   };
 
   outputs = {
@@ -71,6 +84,14 @@ command = "nix-search-tv print"
 
 [preview]
 command = "nix-search-tv preview {}"
+
+[actions.install]
+description = "Install package and rebuild system"
+command = "sudo nix-search-tv install {}"
+mode = "execute"
+
+[keybindings]
+enter = "actions.install"
 ```
 
 or use the Home Manager option:
@@ -84,7 +105,7 @@ programs.nix-search-tv.enableTelevisionIntegration = true;
 The most straightforward integration might look like:
 
 ```sh
-alias ns="nix-search-tv print | fzf --preview 'nix-search-tv preview {}' --scheme history"
+alias ns="nix-search-tv print | fzf --preview 'nix-search-tv preview {}' --scheme history | xargs -I {} sudo nix-search-tv install {}"
 ```
 
 > [!NOTE]

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+)
+
+var Install = &cli.Command{
+	Name:      "install",
+	Usage:     "Install a package",
+	UsageText: "nix-search-tv install <channel> <package>",
+	Action:    InstallAction,
+	Flags:     BaseFlags(),
+}
+
+func InstallAction(_ context.Context, cmd *cli.Command) error {
+	fullPkgName := strings.Join(cmd.Args().Slice(), " ")
+	if fullPkgName == "" {
+		return errors.New("package name is required")
+	}
+
+	conf, err := GetConfig(cmd)
+	if err != nil {
+		return fmt.Errorf("get config: %w", err)
+	}
+
+	if cmd.IsSet(IndexesFlag) {
+		conf.Indexes = cmd.StringSlice(IndexesFlag)
+	}
+
+	_, err = SetupIndexes(conf)
+	if err != nil {
+		return err
+	}
+
+	var pkgName string
+
+	if len(conf.Indexes) == 1 {
+		pkgName = fullPkgName
+	} else {
+		var ok bool
+		_, pkgName, ok = cutIndexPrefix(fullPkgName)
+		if !ok {
+			return errors.New("multiple indexes requested, but the package has no index prefix")
+		}
+	}
+
+	fmt.Printf("Installing %s\n", pkgName)
+
+	if err := writePackageToConfig(pkgName); err != nil {
+		fmt.Printf("Error writing to config: %v\n", err)
+		return nil
+	}
+
+	// current process should run as sudo
+	cmd2 := exec.Command("nixos-rebuild", "switch")
+	cmd2.Stdout = os.Stdout
+	cmd2.Stderr = os.Stderr
+	if err := cmd2.Run(); err != nil {
+		fmt.Printf("Error rebuilding: %v\n", err)
+	}
+
+	return nil
+}
+
+func getLineToWrite(path string, pkgName string) (int, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("read file: %w", err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	startLine := -1
+	foundBlock := false
+
+	// 1. Find the start of the block
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, "environment.systemPackages =") && strings.HasSuffix(trimmed, "[") {
+			startLine = i
+			foundBlock = true
+			break
+		}
+	}
+
+	if !foundBlock {
+		return 0, fmt.Errorf("could not find environment.systemPackages block")
+	}
+
+	// 2. Read next lines one by one
+	for i := startLine + 1; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+
+		// 3. Skip empty lines and comments
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// 5. Check if package matching the trimmed line
+		if trimmed == pkgName {
+			return 0, fmt.Errorf("package '%s' is already installed", pkgName)
+		}
+
+		// 4. Check for closing bracket (end of list)
+		if trimmed == "];" || trimmed == "]" {
+			return i, nil
+		}
+	}
+
+	return 0, fmt.Errorf("could not find closing bracket for environment.systemPackages")
+}
+
+func writePackageToConfig(pkgName string) error {
+	path := "/etc/nixos/configuration.nix"
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return errors.New("configuration.nix not found")
+	}
+
+	lineNum, err := getLineToWrite(path, pkgName)
+	if err != nil {
+		return err
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	line := lines[lineNum]
+
+	// Determine indentation (heuristic: same as indentation of closing bracket + 2 spaces)
+	indent := ""
+	for _, r := range line {
+		if r == ' ' || r == '\t' {
+			indent += string(r)
+		} else {
+			break
+		}
+	}
+	newIndent := indent + "  "
+
+	// Construct the new line
+	newLine := newIndent + pkgName
+
+	// Insert the new line into the slice
+	// We need to insert at index lineNum
+	newLines := append(lines[:lineNum], append([]string{newLine}, lines[lineNum:]...)...)
+
+	// Join lines and write back to file
+	newContent := strings.Join(newLines, "\n")
+	if err = os.WriteFile(path, []byte(newContent), 0644); err != nil {
+		return err
+	}
+
+	fmt.Println("Successfully added package to configuration.nix")
+	return nil
+}

--- a/cmd/nix-search-tv/main.go
+++ b/cmd/nix-search-tv/main.go
@@ -21,6 +21,7 @@ var root = &cli.Command{
 		cmd.Preview,
 		cmd.Source,
 		cmd.Homepage,
+		cmd.Install,
 	},
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
           (mkScript "run" "$DEV_DIR/bin/nix-search-tv $@ --config $DEV_DIR/config.json")
           (mkScript "print-search" "run print")
           (mkScript "preview-search" "run preview $@")
+          (mkScript "install-pkg" "run install $@")
 
           (mkScript "test-integrations" "build && GOEXPERIMENT=jsonv2 NIX_SEARCH_TV_BIN=$DEV_DIR/bin/nix-search-tv go test --count 1 -v ./tests/...")
 


### PR DESCRIPTION
Hello, thanks for this cool project.
I'm new to nix and I wanted to have a more streamlined experience to search and install nix packages quickly, a bit like the AUR helper `yay` on Arch.
So I created a [fork](https://github.com/gschurck/nix-search-tv-install) to add an `install` command that basically adds the package in `configuration.nix` file and rebuild the system automatically. The command works alone and with both television and fzf.
Would you be interested in including it in the main project or is it out of scope ?

It's quite simple for now it only works with system packages in `/etc/nixos/configuration.nix` if the file respects the nixfmt formatting.
But if you are interested I can adapt it to work with any path, with user packages and add tests. (and maybe an `uninstall` command ?)