### PR TITLE
nixpkgs & nur: print package outputs in preview

### DIFF
--- a/indexes/nixpkgs/package.go
+++ b/indexes/nixpkgs/package.go
@@ -11,8 +11,10 @@ import (
 
 type Package struct {
 	indexer.Package
-	Meta    Meta   `json:"meta"`
-	Version string `json:"version"`
+	Meta       Meta           `json:"meta"`
+	Version    string         `json:"version"`
+	Outputs    map[string]any `json:"outputs"`
+	OutputName string         `json:"outputName"`
 }
 
 type Meta struct {

--- a/indexes/nixpkgs/preview.go
+++ b/indexes/nixpkgs/preview.go
@@ -68,6 +68,14 @@ func (pkg *Package) Preview(out io.Writer) {
 		)
 		fmt.Fprintln(out, platforms)
 	}
+
+	if num := len(pkg.Outputs); num > 0 {
+		outputs := textutil.Prop(
+			textutil.IfElse(num > 1, "outputs", "output"), "",
+			textutil.Outputs(pkg.Outputs, pkg.OutputName),
+		)
+		fmt.Fprintln(out, outputs)
+	}
 }
 
 func licensesString(ls []License) string {

--- a/indexes/nur/preview.go
+++ b/indexes/nur/preview.go
@@ -65,6 +65,14 @@ func (pkg *Package) Preview(out io.Writer) {
 		)
 		fmt.Fprintln(out, platforms)
 	}
+
+	if num := len(pkg.Outputs); num > 0 {
+		outputs := textutil.Prop(
+			textutil.IfElse(num > 1, "outputs", "output"), "",
+			textutil.Outputs(pkg.Outputs, pkg.OutputName),
+		)
+		fmt.Fprintln(out, outputs)
+	}
 }
 
 func licensesString(ls []nixpkgs.License) string {

--- a/indexes/textutil/textutil.go
+++ b/indexes/textutil/textutil.go
@@ -1,6 +1,7 @@
 package textutil
 
 import (
+	"maps"
 	"runtime"
 	"slices"
 	"strings"
@@ -72,6 +73,20 @@ func Platforms(platforms []string) string {
 			printable = style.TextStyle.Dim(printable)
 		}
 		toPrint = append(toPrint, printable)
+	}
+
+	return strings.Join(toPrint, "\n")
+}
+
+func Outputs(outputs map[string]any, outputName string) string {
+	toPrint := []string{outputName}
+
+	for _, output := range slices.Sorted(maps.Keys(outputs)) {
+		if output == outputName {
+			continue
+		}
+
+		toPrint = append(toPrint, style.TextStyle.Dim(output))
 	}
 
 	return strings.Join(toPrint, "\n")

--- a/tests/integrations_test.go
+++ b/tests/integrations_test.go
@@ -154,7 +154,7 @@ func testIntegration(t *testing.T, cmdArgs CmdArgs, expected string) {
 	output, err := pane.Capture()
 	assert.NoError(t, err)
 
-	assert.Equal(t, expected, output, "Command: ", cmd.String())
+	assert.Equal(t, expected, output, "Command: %s", cmd.String())
 }
 
 func newSession(

--- a/tests/testdata/cases/fzf-multiple.txt
+++ b/tests/testdata/cases/fzf-multiple.txt
@@ -10,8 +10,8 @@
 ▌ home-manager/ programs.git.difftast·· │ x86_64-darwin                        │
 ▌ home-manager/ programs.firefox.prof·· │ aarch64-darwin                       │
 ▌ home-manager/ home.pointerCursor.hy·· │                                      │
-▌ nixpkgs/ sbclPackages.cl-glfw-openg·· │                                      │
-▌ nixpkgs/ rPackages.minfiData          │                                      │
+▌ nixpkgs/ sbclPackages.cl-glfw-openg·· │ output                               │
+▌ nixpkgs/ rPackages.minfiData          │ out                                  │
 ▌ nixpkgs/ rPackages.OOBCurve           │                                      │
 ▌ nixpkgs/ rPackages.BasicSTARRseq      │                                      │
 ▌ nixpkgs/ python313Packages.cppe       │                                      │

--- a/tests/testdata/cases/fzf-single.txt
+++ b/tests/testdata/cases/fzf-single.txt
@@ -10,8 +10,8 @@
                                         │ x86_64-darwin                        │
                                         │ aarch64-darwin                       │
                                         │                                      │
-▌ sbclPackages.cl-glfw-opengl-apple__·· │                                      │
-▌ rPackages.minfiData                   │                                      │
+▌ sbclPackages.cl-glfw-opengl-apple__·· │ output                               │
+▌ rPackages.minfiData                   │ out                                  │
 ▌ rPackages.OOBCurve                    │                                      │
 ▌ rPackages.BasicSTARRseq               │                                      │
 ▌ python313Packages.cppe                │                                      │

--- a/tests/testdata/cases/tv-multiple.txt
+++ b/tests/testdata/cases/tv-multiple.txt
@@ -10,9 +10,9 @@
 │  nixpkgs/ python313Packages.cppe     ││ x86_64-darwin                        █
 │  nixpkgs/ rPackages.BasicSTARRseq    ││ aarch64-darwin                       █
 │  nixpkgs/ rPackages.OOBCurve         ││                                      █
-│  nixpkgs/ rPackages.minfiData        ││                                      █
-│  nixpkgs/ sbclPackages.cl-glfw-open… ││                                      █
-│  home-manager/ home.pointerCursor.h… ││                                      █
+│  nixpkgs/ rPackages.minfiData        ││ output                               █
+│  nixpkgs/ sbclPackages.cl-glfw-open… ││ out                                  █
+│  home-manager/ home.pointerCursor.h… ││                                      ║
 │  home-manager/ programs.firefox.pro… ││                                      ║
 │  home-manager/ programs.git.difftas… ││                                      ║
 │  home-manager/ programs.kakoune.con… ││                                      ║

--- a/tests/testdata/cases/tv-single.txt
+++ b/tests/testdata/cases/tv-single.txt
@@ -10,9 +10,9 @@
 │  python313Packages.cppe              ││ x86_64-darwin                        █
 │  rPackages.BasicSTARRseq             ││ aarch64-darwin                       █
 │  rPackages.OOBCurve                  ││                                      █
-│  rPackages.minfiData                 ││                                      █
-│  sbclPackages.cl-glfw-opengl-apple_… ││                                      █
-│                                      ││                                      █
+│  rPackages.minfiData                 ││ output                               █
+│  sbclPackages.cl-glfw-opengl-apple_… ││ out                                  █
+│                                      ││                                      ║
 │                                      ││                                      ║
 │                                      ││                                      ║
 │                                      ││                                      ║


### PR DESCRIPTION
Many Nix packages have more than one output, and this change makes `preview` list them all.
The output that is built by default (e.g. by `nix build`) is also highlighted.